### PR TITLE
[mcrouter] Add tcp_listen_backlog standalone option

### DIFF
--- a/mcrouter/server.cpp
+++ b/mcrouter/server.cpp
@@ -99,6 +99,7 @@ bool runServer(const McrouterStandaloneOptions& standaloneOpts,
   opts.numThreads = mcrouterOpts.num_proxies;
 
   opts.setPerThreadMaxConns(standaloneOpts.max_conns, opts.numThreads);
+  opts.tcpListenBacklog = standaloneOpts.tcp_listen_backlog;
   opts.worker.defaultVersionHandler = false;
   opts.worker.maxInFlight = standaloneOpts.max_client_outstanding_reqs;
   opts.worker.sendTimeout = std::chrono::milliseconds{

--- a/mcrouter/standalone_options.h
+++ b/mcrouter/standalone_options.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include <sys/socket.h>
+
 #include "mcrouter/options.h"
 
 namespace facebook { namespace memcache { namespace mcrouter {

--- a/mcrouter/standalone_options_list.h
+++ b/mcrouter/standalone_options_list.h
@@ -54,6 +54,11 @@ mcrouter_option_integer(
   "connections based on rlimits. Eviction logic is disabled by default.")
 
 mcrouter_option_integer(
+  int, tcp_listen_backlog, SOMAXCONN,
+  "tcp-listen-backlog", no_short,
+  "TCP listen backlog size")
+
+mcrouter_option_integer(
   uint32_t, max_client_outstanding_reqs, DEFAULT_MAX_CLIENT_OUTSTANDING_REQS,
   "max-client-outstanding-reqs", no_short,
   "Maximum requests outstanding per client (0 to disable)")


### PR DESCRIPTION
Add a way to tune TCP listen backlog for standalone mcrouter.
Closes #93 

Test plan: run mcrouter with

```
  strace -fff -e listen,ioctl,network ./mcrouter -f ~/dev/config.jsonc -p 5000 --tcp-listen-backlog 1357
```

and see 

```
  [pid 18571] listen(23, 1357)            = 0
  [pid 18571] listen(24, 1357)            = 0
```

in `strace` output. Without a command line option it uses 128 (the default SOMAXCONN value).
